### PR TITLE
Make datetime matching more flexible.

### DIFF
--- a/lib/pact/helpers.rb
+++ b/lib/pact/helpers.rb
@@ -34,11 +34,15 @@ module Pact
     end
 
     def like_datetime datetime
+      Pact::Term.new(generate: datetime, matcher: /^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d(\.\d+)?([+-][0-2]\d:[0-5]\d|Z)$/)
+    end
+
+    def like_datetime_without_milliseconds datetime
       Pact::Term.new(generate: datetime, matcher: /^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)$/)
     end
 
     def like_datetime_with_milliseconds datetime
-      Pact::Term.new(generate: datetime, matcher: /^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d{3}([+-][0-2]\d:[0-5]\d|Z)$/)
+      Pact::Term.new(generate: datetime, matcher: /^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)$/)
     end
 
     alias_method :like_datetime_with_miliseconds, :like_datetime_with_milliseconds

--- a/spec/lib/pact/helpers_spec.rb
+++ b/spec/lib/pact/helpers_spec.rb
@@ -57,10 +57,27 @@ module Pact
     end
 
     describe "#like_datetime" do
+
+      [
+        [:without_mills, '2015-08-06T16:53:10+01:00'],
+        [:with_millis, '2015-08-06T16:53:10.123+01:00']
+      ].each do |scenario, date_string|
+        let(:datetime) { date_string }
+
+        it "creates a Pact::Term with DateTime #{scenario} matcher" do
+          expect(like_datetime(datetime)).to eq Pact::Term.new(
+            generate: datetime,
+            matcher: /^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d(\.\d+)?([+-][0-2]\d:[0-5]\d|Z)$/
+          )
+        end
+      end
+    end
+
+    describe "#like_datetime_without_milliseconds" do
       let(:datetime) { '2015-08-06T16:53:10+01:00' }
 
-      it "creates a Pact::Term with DateTime matcher" do
-        expect(like_datetime(datetime)).to eq Pact::Term.new(
+      it "creates a Pact::Term with DateTime and Millisecond precision matcher" do
+        expect(like_datetime_without_milliseconds(datetime)).to eq Pact::Term.new(
           generate: datetime,
           matcher: /^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)$/
         )
@@ -73,7 +90,7 @@ module Pact
       it "creates a Pact::Term with DateTime and Millisecond precision matcher" do
         expect(like_datetime_with_milliseconds(datetime)).to eq Pact::Term.new(
           generate: datetime,
-          matcher: /^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d{3}([+-][0-2]\d:[0-5]\d|Z)$/
+          matcher: /^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)$/
         )
       end
     end


### PR DESCRIPTION
Before this patch the matching of datetimes had two assumptions:
1. That `like_datetime` would accept datetimes without milliseconds
2. That `like_datetime_with_milliseconds` would only accept 3 digits worth of milliseconds.

This PR makes `like_datetime` accept entries both with and without milliseconds and
adds a `like_datetime_without_milliseconds` method for the explicit case where we want
to verify milliseconds are not present